### PR TITLE
FIX: handle posts with deleted users

### DIFF
--- a/plugin.rb
+++ b/plugin.rb
@@ -36,7 +36,7 @@ after_initialize do
     attributes :user_created_at
 
     def user_created_at
-      object.user.created_at
+      object.user.try(:created_at)
     end
   end
 end


### PR DESCRIPTION
When there are deleted posts by users who have been deleted (because they were spammers), staff who click "view hidden posts" will cause an error.